### PR TITLE
Fix kustomization.yaml files for installing kubeflow 1.7

### DIFF
--- a/apps/admission-webhook/upstream/base/kustomization.yaml
+++ b/apps/admission-webhook/upstream/base/kustomization.yaml
@@ -15,8 +15,8 @@ commonLabels:
   app.kubernetes.io/name: poddefaults
 images:
 - name: docker.io/kubeflownotebookswg/poddefaults-webhook
-  newName: docker.io/kubeflownotebookswg/poddefaults-webhook
-  newTag: v1.7.0-rc.0
+  newName: docker.io/vinaychandran/poddefaults-webhook
+  newTag: v1.7.0
 namespace: kubeflow
 generatorOptions:
   disableNameSuffixHash: true

--- a/apps/centraldashboard/upstream/base/kustomization.yaml
+++ b/apps/centraldashboard/upstream/base/kustomization.yaml
@@ -17,8 +17,8 @@ commonLabels:
   app.kubernetes.io/name: centraldashboard
 images:
 - name: docker.io/kubeflownotebookswg/centraldashboard
-  newName: docker.io/kubeflownotebookswg/centraldashboard
-  newTag: v1.7.0-rc.0
+  newName: docker.io/vinaychandran/centraldashboard
+  newTag: v1.7.0
 configMapGenerator:
 - envs:
   - params.env

--- a/apps/jupyter/jupyter-web-app/upstream/base/kustomization.yaml
+++ b/apps/jupyter/jupyter-web-app/upstream/base/kustomization.yaml
@@ -22,8 +22,8 @@ commonLabels:
   kustomize.component: jupyter-web-app
 images:
 - name: docker.io/kubeflownotebookswg/jupyter-web-app
-  newName: docker.io/kubeflownotebookswg/jupyter-web-app
-  newTag: v1.7.0-rc.0
+  newName: docker.io/vinaychandran/jupyter-web-app
+  newTag: v1.7.0
 # We need the name to be unique without the suffix because the original name is what
 # gets used with patches
 configMapGenerator:

--- a/apps/jupyter/notebook-controller/upstream/base/kustomization.yaml
+++ b/apps/jupyter/notebook-controller/upstream/base/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
 - ../default
 images:
 - name: docker.io/kubeflownotebookswg/notebook-controller
-  newName: docker.io/kubeflownotebookswg/notebook-controller
-  newTag: v1.7.0-rc.0
+  newName: docker.io/vinaychandran/notebook-controller
+  newTag: v1.7.0

--- a/apps/profiles/upstream/base/kustomization.yaml
+++ b/apps/profiles/upstream/base/kustomization.yaml
@@ -11,8 +11,8 @@ patchesStrategicMerge:
 
 images:
 - name: docker.io/kubeflownotebookswg/profile-controller
-  newName: docker.io/kubeflownotebookswg/profile-controller
-  newTag: v1.7.0-rc.0
+  newName: docker.io/vinaychandran/profile-controller
+  newTag: v1.7.0
 
 configMapGenerator:
 - name: namespace-labels-data

--- a/apps/profiles/upstream/overlays/kubeflow/kustomization.yaml
+++ b/apps/profiles/upstream/overlays/kubeflow/kustomization.yaml
@@ -28,5 +28,5 @@ vars:
 
 images:
 - name: docker.io/kubeflownotebookswg/kfam
-  newName: docker.io/kubeflownotebookswg/kfam
-  newTag: v1.7.0-rc.0
+  newName: docker.io/vinaychandran/kfam
+  newTag: v1.7.0

--- a/apps/tensorboard/tensorboard-controller/upstream/base/kustomization.yaml
+++ b/apps/tensorboard/tensorboard-controller/upstream/base/kustomization.yaml
@@ -12,5 +12,5 @@ patchesStrategicMerge:
 - patches/add_controller_config.yaml
 images:
 - name: docker.io/kubeflownotebookswg/tensorboard-controller
-  newName: docker.io/kubeflownotebookswg/tensorboard-controller
-  newTag: v1.7.0-rc.0
+  newName: docker.io/vinaychandran/tensorboard-controller
+  newTag: v1.7.0

--- a/apps/tensorboard/tensorboards-web-app/upstream/base/kustomization.yaml
+++ b/apps/tensorboard/tensorboards-web-app/upstream/base/kustomization.yaml
@@ -13,8 +13,8 @@ commonLabels:
   kustomize.component: tensorboards-web-app
 images:
 - name: docker.io/kubeflownotebookswg/tensorboards-web-app
-  newName: docker.io/kubeflownotebookswg/tensorboards-web-app
-  newTag: v1.7.0-rc.0
+  newName: docker.io/vinaychandran/tensorboards-web-app
+  newTag: v1.7.0
 # We need the name to be unique without the suffix because the original name is what
 # gets used with patches
 configMapGenerator:

--- a/apps/volumes-web-app/upstream/base/kustomization.yaml
+++ b/apps/volumes-web-app/upstream/base/kustomization.yaml
@@ -13,8 +13,8 @@ commonLabels:
   kustomize.component: volumes-web-app
 images:
 - name: docker.io/kubeflownotebookswg/volumes-web-app
-  newName: docker.io/kubeflownotebookswg/volumes-web-app
-  newTag: v1.7.0-rc.0
+  newName: docker.io/vinaychandran/volumes-web-app
+  newTag: v1.7.0
 # We need the name to be unique without the suffix because the original name is what
 # gets used with patches
 configMapGenerator:

--- a/contrib/kserve/models-web-app/base/kustomization.yaml
+++ b/contrib/kserve/models-web-app/base/kustomization.yaml
@@ -12,8 +12,8 @@ commonLabels:
 
 images:
 - name: kserve/models-web-app
-  newName: kserve/models-web-app
-  newTag: v0.10.0
+  newName: vinaychandran/models-web-app
+  newTag: latest
 configMapGenerator:
   - name: kserve-models-web-app-config
     literals:


### PR DESCRIPTION
- ARM64 is not supported on https://hub.docker.com/u/kubeflownotebookswg. So it was changed to a docker image addresses that support ARM64