### PR TITLE
fix: outdated api version (knative-serving)

### DIFF
--- a/common/knative/knative-serving/base/upstream/serving-core.yaml
+++ b/common/knative/knative-serving/base/upstream/serving-core.yaml
@@ -5794,7 +5794,7 @@ spec:
   selector:
     role: domainmapping-webhook
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: webhook


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves bug on M1 Mac with the error:
```
error: resource mapping not found for name: "webhook" namespace: "knative-serving" from "STDIN": no matches for kind "HorizontalPodAutoscaler" in version "autoscaling/v2beta2"
ensure CRDs are installed first
```

**Description of your changes:**
Changed autoscaling/v2beta2 to autoscaling/v2

**Checklist:**
- [x] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
